### PR TITLE
feat: add custom header key support to EventSource API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lightweight alternative to react-router.
 - [@react-nano/tsrux](packages/tsrux/README.md)\
 Lightweight alternative to redux-actions, deox, etc.
 - [@react-nano/use-event-source](packages/use-event-source/README.md)\
-Hook for using [Server-Sent-Events](https://developer.mozilla.org/en-US/packages/Web/API/Server-sent_events).
+Hook for using [Server-Sent-Events](https://developer.mozilla.org/en-US/packages/Web/API/Server-sent_events) and support custom header keys.
 - [@react-nano/use-fetch](packages/use-fetch/README.md)\
 Hook for using `fetch()` to GET, POST, etc. requests.
 - [@react-nano/use-graphql](packages/use-graphql/README.md)\

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,6 +1528,12 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
+      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3696,6 +3702,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmmirror.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -8756,9 +8767,13 @@
     },
     "packages/use-event-source": {
       "name": "@react-nano/use-event-source",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "Zlib",
+      "dependencies": {
+        "event-source-polyfill": "^1.0.31"
+      },
       "devDependencies": {
+        "@types/event-source-polyfill": "^1.0.1",
         "@types/react": "^18.0.26",
         "react": "^18.2.0",
         "rimraf": "^3.0.2",
@@ -9944,7 +9959,9 @@
     "@react-nano/use-event-source": {
       "version": "file:packages/use-event-source",
       "requires": {
+        "@types/event-source-polyfill": "^1.0.1",
         "@types/react": "^18.0.26",
+        "event-source-polyfill": "^1.0.31",
         "react": "^18.2.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.9.4"
@@ -10054,6 +10071,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "@types/event-source-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
+      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -11642,6 +11665,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
+    },
+    "event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmmirror.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "event-target-shim": {
       "version": "5.0.1",

--- a/packages/use-event-source/package.json
+++ b/packages/use-event-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-nano/use-event-source",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A lightweight EventSource (server-sent-events) hook for react, written in TypeScript",
   "keywords": [
     "TypeScript",
@@ -29,7 +29,11 @@
   "scripts": {
     "build": "rimraf dist && tsc"
   },
+  "dependencies": {
+    "event-source-polyfill": "^1.0.31"
+  },
   "devDependencies": {
+    "@types/event-source-polyfill": "^1.0.1",
     "@types/react": "^18.0.26",
     "react": "^18.2.0",
     "rimraf": "^3.0.2",

--- a/packages/use-event-source/src/index.ts
+++ b/packages/use-event-source/src/index.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { EventSourcePolyfill, EventSourceConstructor as EventSourceConstructorPolyfill } from 'event-source-polyfill';
 
 type EventSourceConstructor = { new (url: string, eventSourceInitDict?: EventSourceInit): EventSource };
 
@@ -45,4 +46,12 @@ export function useEventSourceListener(
         return undefined;
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [source, ...dependencies]);
+}
+
+export const createESClassWithHeaders = (headers: { [name: string]: string }): EventSourceConstructorPolyfill => {
+    return class ESClass extends EventSourcePolyfill {
+        constructor(url: string, options?: EventSourceInit) {
+            super(url, { ...options, headers });
+        }
+    };
 }


### PR DESCRIPTION
Solved https://github.com/Lusito/react-nano/issues/1.

Thanks to @RunDevelopment and @Lusito help me write these codes in:

* https://github.com/Lusito/react-nano/issues/1
* https://github.com/chaiNNer-org/chaiNNer/issues/1798

Even if the official [EventSource API - MDN Page](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) doesn't support custom header keys, for now, we can use [event-source-polyfill](https://www.npmjs.com/package/event-source-polyfill) to customize in [@react-nano/use-event-source](https://www.npmjs.com/package/@hyler-coop/use-event-source) just using `createESClassWithHeaders` function.

With no breaking changes, It feels so cool to make this contribution.

Feel free to merge this pull request or not. I have already published the downstream version to NPM: https://www.npmjs.com/package/@hyler-coop/use-event-source. But looking forward to make react-nano be better together.
